### PR TITLE
Allow facebook on messenger.com

### DIFF
--- a/data/disconnect.json
+++ b/data/disconnect.json
@@ -10767,6 +10767,7 @@
 	"Messenger": {
 	  "https://www.messenger.com/": [
 	    "facebook.net",
+	    "facebook.com",
 	    "fbcdn.net"
 	   ]
 	 }

--- a/data/disconnect.json
+++ b/data/disconnect.json
@@ -10763,7 +10763,13 @@
           "https://www.saturn.at/": [
             "google-analytics.com"
           ]
-        }
+        },
+	"Messenger": {
+	  "https://www.messenger.com/": [
+	    "facebook.net",
+	    "fbcdn.net"
+	   ]
+	 }
       }
     ]
   }


### PR DESCRIPTION
Just my first test commit to the tracking-protection, could be wrong but was related this 

https://community.brave.com/t/app-for-messenger-is-blocked/65805

I attempted to fix; but no luck https://github.com/brave/adblock-lists/pull/66  